### PR TITLE
Fix release trigger for auto tag workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -8,6 +8,8 @@ on:
 
 permissions:
   contents: write
+  # Needed to trigger other workflows when pushing tags
+  workflows: write
 
 jobs:
   tag:
@@ -18,6 +20,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
 
       - name: Configure git user
         run: |
@@ -39,6 +42,8 @@ jobs:
           echo "next=$next" >> $GITHUB_OUTPUT
 
       - name: Create and push tag
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           git tag ${{ steps.bump.outputs.next }}
           git push origin ${{ steps.bump.outputs.next }}


### PR DESCRIPTION
## Summary
- use a PAT to push tags
- give the workflow permission to trigger others

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_685665bf13988322bbd2c3155dab0c45