### PR TITLE
Remove auto tag push from release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,12 +65,6 @@ jobs:
           next="v${major}.${minor}.${patch}"
           echo "next=$next" >> $GITHUB_OUTPUT
 
-      - name: Create and push tag
-        env:
-          GH_PAT: ${{ secrets.GH_PAT }}
-        run: |
-          git tag ${{ steps.bump.outputs.next }}
-          git push origin ${{ steps.bump.outputs.next }}
 
       - name: Create GitHub Release
         id: create_release

--- a/Readme.md
+++ b/Readme.md
@@ -190,7 +190,7 @@ The resulting binary can be distributed and run on the target platform without r
 ## CI/CD Workflows
 
 ### Release Workflow
-The release workflow is triggered on every push to a tag matching the pattern `v*`. It builds the project, runs tests, and creates a GitHub release with the compiled binary.
+The release workflow is triggered when a pull request to `main` is merged. It builds the project, runs tests, and creates a GitHub release with the compiled binary.
 
 ### Build and Test Workflow
 The build-and-test workflow is triggered on every push to the `main` branch. It builds the project and runs tests to ensure code quality before merging changes into the main branch.


### PR DESCRIPTION
## Summary
- remove tag creation step from release workflow
- document PR-merge trigger in README

## Testing
- `go build ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68566f02a6a08322805303465da2550c