### PR TITLE
Update release workflow to run on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,9 @@
 name: Release
 
 on:
-  pull_request:
-    types: [closed]
-    branches:
-      - main
+  push:
+    tags:
+      - 'v*'
 
 permissions:
   contents: write
@@ -12,7 +11,6 @@ permissions:
 
 jobs:
   build:
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     name: Build and Release
     runs-on: ubuntu-latest
 
@@ -46,32 +44,14 @@ jobs:
           fi
           chmod +x dist/ultimate-setup-linux-amd64
 
-      - name: Configure git user
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Determine next tag
-        id: bump
-        run: |
-          latest=$(git tag --list 'v0.*' --sort=-v:refname | head -n 1)
-          echo "Latest tag: $latest"
-          if [ -z "$latest" ]; then
-            latest="v0.0.0"
-          fi
-          version=${latest#v}
-          IFS='.' read -r major minor patch <<< "$version"
-          patch=$((patch+1))
-          next="v${major}.${minor}.${patch}"
-          echo "next=$next" >> $GITHUB_OUTPUT
 
 
       - name: Create GitHub Release
         id: create_release
         uses: actions/create-release@v1
         with:
-          tag_name: ${{ steps.bump.outputs.next }}
-          release_name: Release ${{ steps.bump.outputs.next }}
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref_name }}
           draft: false
           prerelease: false
         env:
@@ -103,7 +83,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-and-test:
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     name: Build and Test
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary
- trigger `release.yml` on tag pushes
- remove tag handling steps

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_685682a869d88322803f2af2171c963b